### PR TITLE
Move `ModelCache` from `risclog.kravagimport` to here

### DIFF
--- a/src/risclog/sqlalchemy/cache.py
+++ b/src/risclog/sqlalchemy/cache.py
@@ -1,0 +1,346 @@
+from itertools import chain
+
+import sqlalchemy
+from sqlalchemy.inspection import inspect
+
+
+class MultipleObjectsFoundException(Exception):
+    """Raised when a single result was expected but multiple were found."""
+
+    pass
+
+
+class ModelCache:
+    """
+    A cache for SQLAlchemy ORM model instances, used to enhance performance
+    when working with a large number of database operations.
+
+    Database requests are reduced to a fetching request per model
+    (requesting all model instances) and an updating/inserting request when
+    `save_changes` is called.
+    To achieve this, model instance references are stored and continually
+    indexed by the attributes they have been filtered on.
+
+    Use the methods `get()`, `find()`, `create()` and `get_or_create()` to
+    query the cache or insert new instances. Use `save_changes()` to flush
+    changes to the database and clearing the cache.
+
+    For setup, `ModelCache` currently needs some metadata about the models
+    it should handle. Namely, the order in which models will be saved should
+    be specified by an iterable (`save_order`). Use this to handle foreign key
+    dependencies between your tables.
+    Additionally, a dictionary `sequences` specifies model attributes and
+    corresponding sequences that will be set during flushing. Use this for
+    example for primary keys that normally are set automatically when creating
+    a new table row.
+
+    For performance gains, `save_changes()` flushes by using SQLAlchemy's bulk
+    functionality which explicitly reduces the ORM behavior. Make sure to not
+    use model instances after you have flushed them. These instances are
+    neither connected to a session nor are they updated accordingly.
+    For more information, see: https://docs.sqlalchemy.org/en/13/orm/persistence_techniques.html#bulk-operations
+    """  # noqa: E501
+
+    def __init__(
+            self,
+            save_order,
+            sequences,
+            session,
+            engine_name,
+            prefetch=None
+    ):
+        """
+        Args:
+            save_order: Iterable of model names, specifying the order in
+            which models will be saved. Used to solve dependency constraints.
+            sequences: Dictionary that matches models' attributes to
+            database sequences that are set automatically on flusing. Example:
+            {'Model': (('attribute', 'sequence'), )}
+            session: SQLAlchemy session used for flushing by default.
+            prefetch: Specifies if certain relations should be prefetched.
+            engine_name: Name of the engine used for sequence fetching.
+            Dictionary mapping model names to tuples of columns.
+        """
+        self._save_order = save_order
+        self._sequences = sequences
+        self.session = session
+        self._engine_name = engine_name
+        self._prefetch = prefetch
+        self._cached_instances = {}
+        self._indices = {}
+
+    def find(self, model, **kwargs):
+        """
+        Find `model` instances with matching `kwargs`.
+
+        Returns:
+            A list of matching `model` instances or an empty list.
+        """
+        attribute_index = self._get_attribute_index(model, kwargs.keys())
+        instance_key = tuple(kwargs[attr] for attr in sorted(kwargs.keys()))
+        return attribute_index.get(instance_key, [])
+
+    def get(self, model, **kwargs):
+        """
+        Find a single `model` instance witch matching `kwargs`.
+
+        Returns:
+            A matching `model` instance or None.
+
+        Raises:
+            MultipleObjectsFoundException: Multiple objects were found.
+        """
+        result = self.find(model, **kwargs)
+        if len(result) == 0:
+            return None
+        elif len(result) > 1:
+            raise MultipleObjectsFoundException()
+        return result[0]
+
+    def create(self, model, **kwargs):
+        """
+        Create a `model` instance with `kwargs` as attributes.
+
+        Returns:
+            The newly created `model` instance.
+        """
+        model_cache = self._get_model_cache(model)
+        model_indices = self._get_model_indices(model)
+
+        instance = model(**kwargs)
+        model_cache.append(instance)
+
+        for attribute_key in model_indices.keys():
+            instance_key = self._object_instance_key(instance, attribute_key)
+            cache = model_indices[attribute_key].setdefault(instance_key, [])
+            if instance not in cache:
+                cache.append(instance)
+
+        return instance
+
+    def get_or_create(self, model, **kwargs):
+        """
+        Find or create a `model` instance witch matching `kwargs`.
+
+        Returns:
+            A matching or newly created `model` instance.
+
+        Raises:
+            MultipleObjectsFoundException: Multiple objects were found.
+        """
+        instance = self.get(model, **kwargs)
+        if instance is not None:
+            return instance
+        else:
+            return self.create(model, **kwargs)
+
+    def save_changes(self, session=None):
+        """
+        Flush modified and created object to the database before clearing the
+        cache.
+
+        Args:
+            session: A SQLAlchemy session to use instead of the default one.
+        """
+        if session is None:
+            session = self.session
+
+        self._assign_sequences()
+        self._sync_relationship_attrs()
+
+        objects = chain(
+            *(
+                self._cached_instances[model]
+                for model in self._save_order
+                if model in self._cached_instances
+            )
+        )
+        session.bulk_save_objects(
+            objects,
+            return_defaults=False,
+            update_changed_only=True,
+            preserve_order=True,
+        )
+        session.flush()
+
+        self.clear()
+
+    def clear(self):
+        """Clear the cache. Will result in data loss of unflushed objects."""
+        self._cached_instances.clear()
+        self._indices.clear()
+
+    def _get_model_cache(self, model):
+        """
+        Return a list of every existing and newly created instance of `model`.
+        """
+        model_key = self._model_key(model)
+
+        if model_key not in self._cached_instances:
+            # Initialize model cache if it doesn't exist yet.
+            query = model.query()
+
+            if self._prefetch is not None and model_key in self._prefetch:
+                query = query.options(
+                    sqlalchemy.orm.joinedload(
+                        *[attr for attr in self._prefetch[model_key]]
+                    )
+                )
+
+            self._cached_instances[model_key] = list(query.all())
+            self._register_change_handler(model, self._instance_change_handler)
+
+        return self._cached_instances[model_key]
+
+    def _get_model_indices(self, model):
+        """
+        Return a dictionary containing tuples of indexed attributes as keys.
+        """
+        model_key = self._model_key(model)
+        if model_key not in self._indices:
+            self._indices[model_key] = {}
+        return self._indices[model_key]
+
+    def _get_attribute_index(self, model, attributes):
+        """
+        Return a dictionary containing model attribute values as keys and a
+        list of matching instances as values.
+        """
+        model_indices = self._get_model_indices(model)
+        attribute_key = tuple(sorted(attributes))
+
+        if attribute_key not in model_indices:
+            model_cache = self._get_model_cache(model)
+            indexed_instances = {}
+            for instance in model_cache:
+                instance_key = self._object_instance_key(
+                    instance, attribute_key
+                )
+                cache = indexed_instances.setdefault(instance_key, [])
+                cache.append(instance)
+            model_indices[attribute_key] = indexed_instances
+
+        return model_indices[attribute_key]
+
+    def _model_key(self, model):
+        """
+        Return the key used to reference a given `model` in the instance cache
+        and indices.
+        """
+        return model.__name__
+
+    def _object_instance_key(self, instance, attribute_key, replace=None):
+        """
+        Return the index key to reference a given `instance`given an
+        `attribute_key`.
+        """
+        attributes = {name: getattr(instance, name) for name in attribute_key}
+        if replace is not None:
+            attributes.update(replace)
+        return tuple(attributes[name] for name in attribute_key)
+
+    def _assign_sequences(self):
+        """
+        Assign sequence values to empty model attributes specified in the
+        constructor.
+
+        This iterates over every cached model and its corresponding sequences
+        and assigns sequence values where applicable..
+        Empty sequence attributes are counted and matching sequence values are
+        fetched from the database in a single request.
+        """
+        for model_name, objects in self._cached_instances.items():
+            if model_name not in self._sequences:
+                continue
+
+            model_sequences = self._sequences[model_name]
+            for sequence in model_sequences:
+                new_objects = list(
+                    filter(lambda o: getattr(o, sequence[0]) is None, objects)
+                )
+                if len(new_objects) > 0:
+                    sequence_values = self.session.using_bind(
+                        self._engine_name
+                    ).execute(
+                        "select nextval('%s') from generate_series(1,%s)"
+                        % (sequence[1], len(new_objects))
+                    )
+
+                    for object, value in zip(new_objects, sequence_values):
+                        setattr(object, sequence[0], value[0])
+
+    def _sync_relationship_attrs(self):
+        """
+        Synchronize relationship attributes with their corresponding ID
+        attributes.
+
+        When using SQLAlchemy bulk functionality, the ORM behavior is changed
+        in multiple ways. One important change is that relationship attributes
+        aren't evaluated anymore.
+        To still handle related object as expected, we iterate over
+        relationship attributes and set their corresponding ID attributes on
+        the same object.
+        """
+        for objects in self._cached_instances.values():
+            if len(objects) == 0:
+                continue
+            model = type(list(objects)[0])
+
+            rel_map = [
+                (rel.key, pair[1].key, pair[0].key)
+                for rel in inspect(model).relationships
+                for pair in rel.local_remote_pairs
+                if rel.direction is not sqlalchemy.orm.interfaces.ONETOMANY
+            ]
+            for object in objects:
+                for from_obj, from_attr, to_attr in rel_map:
+                    if getattr(object, to_attr, None) is None:
+                        setattr(
+                            object,
+                            to_attr,
+                            getattr(
+                                getattr(object, from_obj), from_attr, None
+                            ),
+                        )
+
+    def _register_change_handler(self, model, event_handler):
+        """Register an event handler for every column of a model."""
+        for attr in inspect(model).column_attrs:
+            sqlalchemy.event.listen(attr, 'set', event_handler)
+
+    def _instance_change_handler(self, instance, value, oldvalue, initiator):
+        """
+        Re-index model instances that were changed
+        (to keep the index up-to-date).
+        Called by SQLAlchemy's model `set` event which fires when a model
+        attribute was changed. For more information, see: https://docs.sqlalchemy.org/en/13/orm/events.html
+        """  # noqa: E501
+        if oldvalue is sqlalchemy.util.symbol('NEVER_SET'):
+            return
+
+        model = type(instance)
+        changed_attr = initiator.key
+        model_indices = self._get_model_indices(model)
+
+        for attribute_key in model_indices.keys():
+            if changed_attr not in attribute_key:
+                continue
+
+            old_instance_key = self._object_instance_key(
+                instance, attribute_key, replace={changed_attr: oldvalue}
+            )
+            new_instance_key = self._object_instance_key(
+                instance, attribute_key, replace={changed_attr: value}
+            )
+
+            old_cache = model_indices[attribute_key].get(old_instance_key, [])
+            if len(old_cache) > 1:
+                old_cache.remove(instance)
+            else:
+                model_indices[attribute_key].pop(old_instance_key, [])
+
+            cache = model_indices[attribute_key].setdefault(
+                new_instance_key, []
+            )
+            if instance not in cache:
+                cache.append(instance)

--- a/src/risclog/sqlalchemy/tests/conftest.py
+++ b/src/risclog/sqlalchemy/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 import risclog.sqlalchemy.testing
 import risclog.sqlalchemy.serializer
 
@@ -13,6 +14,12 @@ def database_1(request):
 def database_2(request):
     return risclog.sqlalchemy.testing.database_fixture_factory(
         request, 'risclog.sqlalchemy.db2', 'db2')
+
+
+@pytest.fixture(scope='session')
+def database_3(request):
+    return risclog.sqlalchemy.testing.database_fixture_factory(
+        request, 'risclog.sqlalchemy.db3', 'db3')
 
 
 @pytest.fixture(scope='function', autouse=True)

--- a/src/risclog/sqlalchemy/tests/test_cache.py
+++ b/src/risclog/sqlalchemy/tests/test_cache.py
@@ -1,0 +1,222 @@
+import pytest
+import sqlalchemy
+from sqlalchemy import Column, ForeignKey, Integer, String
+
+from .. import model
+from ..cache import ModelCache, MultipleObjectsFoundException
+
+
+class TestObject(model.ObjectBase):
+    _engine_name = 'db3'
+
+
+Object = model.declarative_base(TestObject)
+
+
+class PlainModel(Object):
+    id = Column(String(10), primary_key=True)
+    titel = Column(String(100))
+
+
+class LinkedModel(Object):
+    id = Column(String(10), primary_key=True)
+    sequence_model_id = Column(
+        Integer,
+        ForeignKey('sequencemodel.id'),
+        primary_key=True,
+    )
+    sequence_model = sqlalchemy.orm.relation('SequenceModel', uselist=False)
+
+
+class SequenceModel(Object):
+    id = Column(Integer, autoincrement=True, primary_key=True)
+    titel = Column(String)
+
+
+@pytest.fixture(scope='session')
+def db(database_3):
+    database_3.create_all('db3')
+    return database_3
+
+
+@pytest.fixture(scope='function')
+def cache(db):
+    MODEL_SAVE_ORDER = [
+        'PlainModel',
+        'LinkedModel',
+        'SequenceModel',
+        'KFZVertrag',
+    ]
+    MODEL_SEQUENCES = {
+        'Wagniskennziffer': (('id', 'sequencemodel_id_seq'),),
+    }
+    cache = ModelCache(
+        save_order=MODEL_SAVE_ORDER,
+        sequences=MODEL_SEQUENCES,
+        session=db.session,
+        engine_name='db3',
+    )
+    yield cache
+
+
+class TestFindGet:
+    def test_find_uncached_object(self, cache):
+        svg = PlainModel.create(id='1', )
+
+        assert svg == cache.get(PlainModel, id=svg.id, )
+        assert svg == cache.find(PlainModel, id=svg.id, )[0]
+
+    def test_find_cached_object(self, cache):
+        svg = cache.create(PlainModel, id='1')
+
+        assert svg == cache.get(PlainModel, id=svg.id, )
+        assert svg == cache.find(PlainModel, id=svg.id, )[0]
+
+    def test_find_multiple_objects(self, cache):
+        svg1 = PlainModel.create(id='1', titel='')
+        svg2 = PlainModel.create(id='2', titel='')
+
+        result = cache.find(PlainModel, titel='')
+
+        assert 2 == len(result)
+        assert svg1 in result
+        assert svg2 in result
+
+    def test_get_multiple_objects(self, cache):
+        PlainModel.create(id='1', titel='')
+        PlainModel.create(id='2', titel='')
+
+        with pytest.raises(MultipleObjectsFoundException):
+            cache.get(PlainModel, titel='')
+
+    def test_non_existent_object(self, cache):
+        PlainModel.create(id='1', )
+        cache.create(
+            PlainModel, id='2',
+        )
+
+        assert None is cache.get(PlainModel, id='3', )
+        assert [] == cache.find(PlainModel, id='3', )
+
+    def test_attribute_update(self, cache):
+        svg = cache.create(PlainModel, id='1')
+        cache.get(
+            PlainModel, id=svg.id,
+        )
+
+        svg.id = '2'
+
+        assert svg == cache.get(PlainModel, id=svg.id, )
+        assert svg == cache.find(PlainModel, id=svg.id, )[0]
+
+
+class TestCreate:
+    def test_create_object(self, db, cache):
+        cache.create(
+            PlainModel, id='1',
+        )
+        cache.save_changes(db.session)
+
+        assert 1 == PlainModel.query().count()
+
+
+class TestFlush:
+    def test_creation(self, db, cache):
+        svg = cache.create(PlainModel, id='1', )
+        cache.save_changes(db.session)
+
+        assert 1 == PlainModel.query().filter(PlainModel.id == svg.id).count()
+
+    def test_update(self, db, cache):
+        old_id, new_id = '1', '42'
+        PlainModel.create(id=old_id, )
+        svg = cache.get(PlainModel, id=old_id, )
+
+        svg.id = new_id
+        cache.save_changes(db.session)
+
+        assert 0 == PlainModel.query().filter(PlainModel.id == old_id).count()
+        assert 1 == PlainModel.query().filter(PlainModel.id == new_id).count()
+
+    def test_sequence_set_if_missing(self, db, cache):
+        cache.create(
+            SequenceModel, id=None,
+        )
+        cache.save_changes(db.session)
+        wkz = SequenceModel.query().one()
+
+        assert None is not wkz.id
+
+    def test_existing_sequence_ignored(self, db, cache):
+        id = 42
+        cache.create(
+            SequenceModel, id=id,
+        )
+        cache.save_changes(db.session)
+        wkz = SequenceModel.query().one()
+
+        assert id == wkz.id
+
+    def test_synced_relationships(self, db, cache):
+        sequence_model = SequenceModel.create()
+        cache.create(LinkedModel, id='1', sequence_model=sequence_model)
+        cache.save_changes(db.session)
+        partner = LinkedModel.query().one()
+
+        assert sequence_model == partner.sequence_model
+        assert sequence_model.id == partner.sequence_model_id
+
+
+class TestIndex:
+    def test_find_populates_indices(self, cache):
+        svg = PlainModel.create(id='1', )
+        cache.find(
+            PlainModel, id=svg.id,
+        )
+        cache.find(PlainModel, id=svg.id, titel='')
+
+        assert [svg] == cache._cached_instances['PlainModel']
+        assert [svg] == cache._indices['PlainModel'][('id',)][(svg.id,)]
+        assert [svg] == cache._indices['PlainModel'][('id', 'titel')][
+            (svg.id, svg.titel)
+        ]
+
+    def test_get_populates_indices(self, cache):
+        svg = PlainModel.create(id='1', )
+        cache.get(
+            PlainModel, id=svg.id,
+        )
+        cache.get(PlainModel, id=svg.id, titel='')
+
+        assert [svg] == cache._cached_instances['PlainModel']
+        assert [svg] == cache._indices['PlainModel'][('id',)][(svg.id,)]
+        assert [svg] == cache._indices['PlainModel'][('id', 'titel')][
+            (svg.id, svg.titel)
+        ]
+
+    def test_attribute_changes_update_indices(self, cache):
+        old_id, new_id = '1', '2'
+        svg = PlainModel.create(id=old_id, )
+        cache.get(
+            PlainModel, id=svg.id,
+        )
+
+        svg.id = new_id
+
+        assert [svg] == cache._cached_instances['PlainModel']
+        assert [svg] == cache._indices['PlainModel'][('id',)][(new_id,)]
+        assert (old_id,) not in cache._indices['PlainModel'][('id',)]
+
+    def test_attribute_changes_update_indices2(self, cache):
+        old_titel, new_titel = 'Old', 'New'
+        svg1 = PlainModel.create(id='1', titel=old_titel)
+        svg2 = PlainModel.create(id='2', titel=old_titel)
+        cache.find(
+            PlainModel, titel=old_titel,
+        )
+
+        svg1.titel = new_titel
+
+        assert [svg1, svg2] == cache._cached_instances['PlainModel']
+        assert [svg1] == cache._indices['PlainModel'][('titel',)][(new_titel,)]
+        assert [svg2] == cache._indices['PlainModel'][('titel',)][(old_titel,)]


### PR DESCRIPTION
`ModelCache` will be used both in `kravagimport` and `kravagportal`.
As it doesn't depend on either project, we'll maintain it in `sqlalchemy`.