### PR TITLE
Use PostgreSQL's `COPY` in `ModelCache` for performance gains

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,10 @@
 Change log for risclog.sqlalchemy
 =================================
 
-4.7 (unreleased)
+5.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Use PostgreSQL's `COPY` in `ModelCache` for performance gains. Drop Python2 support. (#13317)
 
 
 4.6 (2020-07-21)

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,6 @@ License :: OSI Approved :: Zope Public License
 Natural Language :: English
 Operating System :: OS Independent
 Programming Language :: Python
-Programming Language :: Python :: 2
-Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import glob
 
 setup(
     name='risclog.sqlalchemy',
-    version='4.7.dev0',
+    version='5.0.dev0',
 
     install_requires=[
         'SQLAlchemy >= 1.0',

--- a/src/risclog/sqlalchemy/cache.py
+++ b/src/risclog/sqlalchemy/cache.py
@@ -1,7 +1,8 @@
-from itertools import chain
+from itertools import chain, groupby
 
 import sqlalchemy
 from sqlalchemy.inspection import inspect
+from sqlalchemy.orm import attributes
 
 
 class MultipleObjectsFoundException(Exception):
@@ -56,7 +57,7 @@ class ModelCache:
             save_order: Iterable of model names, specifying the order in
             which models will be saved. Used to solve dependency constraints.
             sequences: Dictionary that matches models' attributes to
-            database sequences that are set automatically on flusing. Example:
+            database sequences that are set automatically on flushing. Example:
             {'Model': (('attribute', 'sequence'), )}
             session: SQLAlchemy session used for flushing by default.
             prefetch: Specifies if certain relations should be prefetched.
@@ -150,6 +151,11 @@ class ModelCache:
         if session is None:
             session = self.session
 
+        for instance_cache in self._cached_instances.values():
+            if len(instance_cache) == 0:
+                continue
+            self._deregister_change_handler(type(instance_cache[0]), self._instance_change_handler)
+
         self._log('info', 'Flushing model cache.')
         self._assign_sequences()
         self._sync_relationship_attrs()
@@ -161,16 +167,50 @@ class ModelCache:
                 if model in self._cached_instances
             )
         )
-        session.bulk_save_objects(
+
+        self._bulk_save_objects(
+            session,
             objects,
             return_defaults=False,
             update_changed_only=True,
-            preserve_order=True,
+            preserve_order=False,
         )
         session.flush()
 
         self.clear()
         self._log('info', 'Flushed model cache.')
+
+    def _bulk_save_objects(
+            self,
+            session,
+            objects,
+            return_defaults=False,
+            update_changed_only=True,
+            preserve_order=True
+    ):
+        def sort_key(state):
+            return state.key is not None
+
+        def group_key(state):
+            return state.mapper, state.key is not None
+
+        obj_states = (attributes.instance_state(obj) for obj in objects)
+        if not preserve_order:
+            obj_states = sorted(obj_states, key=sort_key)
+
+        for (mapper, isupdate), states in groupby(obj_states, group_key):
+            # XXX We are relying on SQLAlchem implementation details here
+            # because there is no otherway to keep it from sorting by
+            # mapping (which already happened).
+            session._bulk_save_mappings(
+                mapper,
+                states,
+                isupdate,
+                True,
+                return_defaults,
+                update_changed_only,
+                False,
+            )
 
     def clear(self):
         """Clear the cache. Will result in data loss of unflushed objects."""
@@ -319,6 +359,11 @@ class ModelCache:
 
     def _register_change_handler(self, model, event_handler):
         """Register an event handler for every column of a model."""
+        for attr in inspect(model).column_attrs:
+            sqlalchemy.event.listen(attr, 'set', event_handler)
+
+    def _deregister_change_handler(self, model, event_handler):
+        """Removes an event handler for every column of a model."""
         for attr in inspect(model).column_attrs:
             sqlalchemy.event.listen(attr, 'set', event_handler)
 

--- a/src/risclog/sqlalchemy/cache.py
+++ b/src/risclog/sqlalchemy/cache.py
@@ -1,4 +1,5 @@
-from itertools import chain, groupby
+import csv
+import io
 
 import sqlalchemy
 from sqlalchemy.inspection import inspect
@@ -35,9 +36,10 @@ class ModelCache:
     example for primary keys that normally are set automatically when creating
     a new table row.
 
-    For performance gains, `save_changes()` flushes by using SQLAlchemy's bulk
-    functionality which explicitly reduces the ORM behavior. Make sure to not
-    use model instances after you have flushed them. These instances are
+    For performance gains, `save_changes()` flushes by using SQLAlchemy's bulk 
+    functionality and/or psycopg2's `copy_expert` method which explicitly 
+    reduces the ORM behavior. 
+    Make sure to not use model instances after you have flushed them. These instances are
     neither connected to a session nor are they updated accordingly.
     For more information, see: https://docs.sqlalchemy.org/en/13/orm/persistence_techniques.html#bulk-operations
     """  # noqa: E501
@@ -51,6 +53,7 @@ class ModelCache:
             prefetch=None,
             preload_models=True,
             logger=None,
+            use_copy=False,
     ):
         """
         Args:
@@ -64,6 +67,7 @@ class ModelCache:
             engine_name: Name of the engine used for sequence fetching.
             Dictionary mapping model names to tuples of columns.
             preload_models: Preloads existing model instances on setup if True.
+            use_copy: Use PostgreSQL's COPY command to insert new instances if True.
         """
         self._save_order = save_order
         self._sequences = sequences
@@ -72,6 +76,7 @@ class ModelCache:
         self._prefetch = prefetch
         self._preload_models = preload_models
         self._logger = logger
+        self._use_copy = use_copy
         self._cached_instances = {}
         self._indices = {}
 
@@ -140,7 +145,7 @@ class ModelCache:
         else:
             return self.create(model, **kwargs)
 
-    def save_changes(self, session=None):
+    def save_changes(self, session=None, cursor=None):
         """
         Flush modified and created object to the database before clearing the
         cache.
@@ -150,66 +155,84 @@ class ModelCache:
         """
         if session is None:
             session = self.session
-
-        for instance_cache in self._cached_instances.values():
-            if len(instance_cache) == 0:
-                continue
-            self._deregister_change_handler(type(instance_cache[0]), self._instance_change_handler)
+        if cursor is None and self._use_copy:
+            cursor = self.session.using_bind(self._engine_name).connection().connection.cursor()
 
         self._log('info', 'Flushing model cache.')
         self._assign_sequences()
         self._sync_relationship_attrs()
 
-        objects = chain(
-            *(
-                self._cached_instances[model]
-                for model in self._save_order
-                if model in self._cached_instances
-            )
-        )
+        for model_name in self._save_order:
+            if model_name not in self._cached_instances:
+                continue
+            objects = self._cached_instances[model_name]
+            if len(objects) == 0:
+                continue
 
-        self._bulk_save_objects(
-            session,
-            objects,
-            return_defaults=False,
-            update_changed_only=True,
-            preserve_order=False,
-        )
-        session.flush()
+            self._deregister_change_handler(type(objects[0]), self._instance_change_handler)
+            new_objects, updated_objects = [], []
+
+            for object in objects:
+                if attributes.instance_state(object).key is None:
+                    new_objects.append(object)
+                else:
+                    updated_objects.append(object)
+
+            if self._use_copy:
+                self._save_by_copy(cursor, new_objects)
+            else:
+                session.bulk_save_objects(new_objects)
+            session.bulk_save_objects(updated_objects)
+            session.flush()
+
+        if self._use_copy:
+           cursor.connection.commit()
 
         self.clear()
         self._log('info', 'Flushed model cache.')
 
-    def _bulk_save_objects(
-            self,
-            session,
-            objects,
-            return_defaults=False,
-            update_changed_only=True,
-            preserve_order=True
-    ):
-        def sort_key(state):
-            return state.key is not None
+    def _save_by_copy(self, cursor, objects):
+        """
+        Insert objects by using PostgreSQL's COPY command. This is database-specific but one of the
+        most efficient ways to populate a table. Expects instances of one single model per call.
+        See: https://www.postgresql.org/docs/current/sql-copy.html
 
-        def group_key(state):
-            return state.mapper, state.key is not None
+        Args:
+            cursor: A Psycopg2 cursor
+            objects: SQLAlchemy ORM instances to save
+        """
+        if len(objects) == 0:
+            return
 
-        obj_states = (attributes.instance_state(obj) for obj in objects)
-        if not preserve_order:
-            obj_states = sorted(obj_states, key=sort_key)
+        model = inspect(objects[0]).mapper
+        for table in model.tables:
+            file = io.StringIO()
+            writer = csv.DictWriter(
+                file, table.columns.keys()
+            )
+            columns = [c for c in model.c.items() if
+                       c[1].table == table or c[1].primary_key]
 
-        for (mapper, isupdate), states in groupby(obj_states, group_key):
-            # XXX We are relying on SQLAlchem implementation details here
-            # because there is no otherway to keep it from sorting by
-            # mapping (which already happened).
-            session._bulk_save_mappings(
-                mapper,
-                states,
-                isupdate,
-                True,
-                return_defaults,
-                update_changed_only,
-                False,
+            for object in objects:
+                row = {}
+                for attr, column in columns:
+                    value = getattr(object, attr)
+                    if value is None:
+                        if column.default is not None:
+                            value = column.default.arg
+                        else:
+                            value = r'\N'
+                    elif type(value) != column.type.python_type:
+                        value = column.type.python_type(value)
+                    row[column.key] = value
+                writer.writerow(row)
+
+            file.seek(0)
+            columns_string = ','.join([f'"{column}"' for column in table.columns.keys()])
+            cursor.copy_expert(
+                f'COPY {table} ({columns_string}) '
+                "FROM STDIN WITH CSV DELIMITER ',' NULL '\\N'",
+                file,
             )
 
     def clear(self):

--- a/src/risclog/sqlalchemy/tests/test_cache.py
+++ b/src/risclog/sqlalchemy/tests/test_cache.py
@@ -39,8 +39,7 @@ def db(database_3):
     return database_3
 
 
-@pytest.fixture(scope='function')
-def cache(db):
+def __create_cache(db, extra_settings=None):
     MODEL_SAVE_ORDER = [
         'PlainModel',
         'LinkedModel',
@@ -50,13 +49,28 @@ def cache(db):
     MODEL_SEQUENCES = {
         'Wagniskennziffer': (('id', 'sequencemodel_id_seq'),),
     }
+    settings = {
+        'save_order': MODEL_SAVE_ORDER,
+        'sequences': MODEL_SEQUENCES,
+        'session': db.session,
+        'engine_name': 'db3',
+    }
+    if extra_settings is not None:
+        settings.update(extra_settings)
     cache = ModelCache(
-        save_order=MODEL_SAVE_ORDER,
-        sequences=MODEL_SEQUENCES,
-        session=db.session,
-        engine_name='db3',
+        **settings
     )
-    yield cache
+    return cache
+
+
+@pytest.fixture(scope='function')
+def cache(db):
+    yield __create_cache(db)
+
+
+@pytest.fixture(scope='function')
+def copy_cache(db):
+    yield __create_cache(db, {'use_copy': True})
 
 
 class TestFindGet:
@@ -119,11 +133,25 @@ class TestCreate:
 
         assert 1 == PlainModel.query().count()
 
+    def test_create_object_with_copy(self, db, copy_cache):
+        copy_cache.create(
+            PlainModel, id='1',
+        )
+        copy_cache.save_changes(db.session)
+
+        assert 1 == PlainModel.query().count()
+
 
 class TestFlush:
     def test_creation(self, db, cache):
         svg = cache.create(PlainModel, id='1', )
         cache.save_changes(db.session)
+
+        assert 1 == PlainModel.query().filter(PlainModel.id == svg.id).count()
+
+    def test_creation_with_copy(self, db, copy_cache):
+        svg = copy_cache.create(PlainModel, id='1', )
+        copy_cache.save_changes(db.session)
 
         assert 1 == PlainModel.query().filter(PlainModel.id == svg.id).count()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py27,
-          py36,
+envlist = py36,
           py37,
           py38,
           py39,


### PR DESCRIPTION
This iteration drops Python 2 support.

See also:
https://github.com/risclog-solution/risclog.kravagimport/pull/5
https://github.com/risclog-solution/risclog.fixinfo/pull/1

Closes RED-13317